### PR TITLE
Make 00-skel.sh less situation-dependent

### DIFF
--- a/etc/profile.d/00-skel.sh
+++ b/etc/profile.d/00-skel.sh
@@ -6,7 +6,7 @@
 export CYGWIN="${CYGWIN}${CYGWIN:+ }winsymlinks"
 
 # mount AppData on $HOME
-if ! mount | grep -e "^$(cygpath --mixed $APPDATA)/Swan on $HOME " >/dev/null; then
+if ! mount | grep -e "^$(cygpath --mixed "$APPDATA")/Swan on $HOME " >/dev/null; then
     mkdir -p "$(cygpath $APPDATA)/Swan"
     mount -fo user "${APPDATA}\\Swan" "$HOME"
 fi

--- a/etc/profile.d/00-skel.sh
+++ b/etc/profile.d/00-skel.sh
@@ -6,17 +6,18 @@
 export CYGWIN="${CYGWIN}${CYGWIN:+ }winsymlinks"
 
 # mount AppData on $HOME
-if ! mount | grep -i "home" >/dev/null; then
+if ! mount | grep -e "^$(cygpath --mixed $APPDATA)/Swan on $HOME " >/dev/null; then
     mkdir -p "$(cygpath $APPDATA)/Swan"
     mount -fo user "${APPDATA}\\Swan" "$HOME"
 fi
 
 
 # ensure skeleton files are updated for new packages
-for bone in `find /etc/skel -type f -printf "%P\n"`; do
-    if [ ! -e $HOME/$bone ]; then
-        mkdir -p `dirname $HOME/$bone`
-        cp /etc/skel/$bone $HOME/$bone
+
+find /etc/skel -type f -printf '%P\n' | while read bone; do
+    if [ ! -e "$HOME/$bone" ]; then
+        mkdir -p "$(dirname "$HOME/$bone")"
+        cp "/etc/skel/$bone" "$HOME/$bone"
     fi
 done
 unset bone


### PR DESCRIPTION
Previously, mounting anything in the user's homedir through `/etc/fstab` would break the user's home directory.  
These changes should more reliably make sure only the intended path is checked.  
This closes starlight/swan-desktop#36.  

While I was at it I also changed the skeleton file section to be more resilient, previously it'd have trouble handling files with special characters and spaces, it should be able to handle pretty much everything now.